### PR TITLE
Explicitly provide reponame and login to github call

### DIFF
--- a/assistants/crt/vala/console.yaml
+++ b/assistants/crt/vala/console.yaml
@@ -41,6 +41,9 @@ run:
 - log_i: 'automake: http://www.gnu.org/software/automake/manual/automake.html'
 - log_i: 'autoconf: http://www.gnu.org/software/autoconf/manual/autoconf.html'
 - if defined $github:
-  - github: create_and_push
+  - github:
+    - create_and_push
+    - reponame: $basename
+      login: $github
 - log_i: 'Console project $basename in $dirname created.'
 

--- a/assistants/crt/vala/gtk.yaml
+++ b/assistants/crt/vala/gtk.yaml
@@ -43,6 +43,9 @@ run:
 - log_i: 'automake: http://www.gnu.org/software/automake/manual/automake.html'
 - log_i: 'autoconf: http://www.gnu.org/software/autoconf/manual/autoconf.html'
 - if defined $github:
-  - github: create_and_push
+  - github:
+    - create_and_push
+    - reponame: $basename
+      login: $github
 - log_i: 'Console project $basename in $dirname created.'
 


### PR DESCRIPTION
The automatic guessing from global variables is going to be removed in the next release of DevAssistant.
